### PR TITLE
Use Ruby Sass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 # Example .gitignore files: https://github.com/github/gitignore
 /node_modules/
 /_site/
+/.sass-cache/

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -13,7 +13,7 @@ module.exports = function(grunt) {
 
         sass: {
             options: {
-                outputStyle: 'compressed',
+                style: 'compressed',
             },
             dist: {
                 files: {
@@ -78,7 +78,7 @@ module.exports = function(grunt) {
 
 
     grunt.loadNpmTasks('grunt-contrib-uglify');
-    grunt.loadNpmTasks('grunt-sass');
+    grunt.loadNpmTasks('grunt-contrib-sass');
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-autoprefixer');
     grunt.loadNpmTasks('grunt-shell');

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "grunt-contrib-sass": "^0.8.1",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-contrib-sass": "*",
+    "grunt-contrib-sass": "^1.0.0",
     "grunt-shell": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "grunt-contrib-sass": "^0.8.1",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-contrib-sass",
+    "grunt-contrib-sass": *,
     "grunt-shell": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "grunt-contrib-sass": "^0.8.1",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-contrib-sass": *,
+    "grunt-contrib-sass": "*",
     "grunt-shell": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "grunt-contrib-sass": "^0.8.1",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-sass": "^0.14.2",
+    "grunt-contrib-sass",
     "grunt-shell": "^1.1.1"
   }
 }


### PR DESCRIPTION
grunt-contrib-sass is slower, but uses the sass ruby gem instead of libsass, which is not available on all platforms